### PR TITLE
adds sdiff alias to git

### DIFF
--- a/generic/git-config-alias-sdiff.sh
+++ b/generic/git-config-alias-sdiff.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# adds sdiff alias to git
+#
+# sdiff stands for 'simple diff', and is a diff that doesn't taking into
+# account file mode changes.
+
+git config --global alias.sdiff "-c core.fileMode=false diff"


### PR DESCRIPTION
sdiff stands for 'simple diff', and is a diff that doesn't taking into account file mode changes.
